### PR TITLE
update SmoothScroll render function to loop only when user is scrolling

### DIFF
--- a/js/demo.js
+++ b/js/demo.js
@@ -236,8 +236,12 @@
                 }
             }
             
-            // loop..
-            requestAnimationFrame(() => this.render());
+            // loop when scrolling..
+            if ( scrollingSpeed !== 0 ) {
+                requestAnimationFrame(() => this.render());
+            } else {
+                window.addEventListener( 'scroll', () => requestAnimationFrame(() => this.render()), { once: true, passive: true })
+            }
         }
     }
 

--- a/js/demo2.js
+++ b/js/demo2.js
@@ -276,8 +276,12 @@
                 }
             }
             
-            // loop..
-            requestAnimationFrame(() => this.render());
+            // loop when scrolling..
+            if ( scrollingSpeed !== 0 ) {
+                requestAnimationFrame(() => this.render());
+            } else {
+                window.addEventListener( 'scroll', () => requestAnimationFrame(() => this.render()), { once: true, passive: true })
+            }
         }
     }
 

--- a/js/demo3.js
+++ b/js/demo3.js
@@ -245,8 +245,12 @@
                 }
             }
             
-            // loop..
-            requestAnimationFrame(() => this.render());
+            // loop when scrolling..
+            if ( scrollingSpeed !== 0 ) {
+                requestAnimationFrame(() => this.render());
+            } else {
+                window.addEventListener( 'scroll', () => requestAnimationFrame(() => this.render()), { once: true, passive: true })
+            }
         }
     }
 

--- a/js/demo4.js
+++ b/js/demo4.js
@@ -251,8 +251,12 @@
                 }
             }
             
-            // loop..
-            requestAnimationFrame(() => this.render());
+            // loop when scrolling..
+            if ( scrollingSpeed !== 0 ) {
+                requestAnimationFrame(() => this.render());
+            } else {
+                window.addEventListener( 'scroll', () => requestAnimationFrame(() => this.render()), { once: true, passive: true })
+            }
         }
     }
 

--- a/js/demo5.js
+++ b/js/demo5.js
@@ -245,8 +245,12 @@
                 }
             }
             
-            // loop..
-            requestAnimationFrame(() => this.render());
+            // loop when scrolling..
+            if ( scrollingSpeed !== 0 ) {
+                requestAnimationFrame(() => this.render());
+            } else {
+                window.addEventListener( 'scroll', () => requestAnimationFrame(() => this.render()), { once: true, passive: true })
+            }
         }
     }
 

--- a/js/demo6.js
+++ b/js/demo6.js
@@ -308,8 +308,12 @@
                 }
             }
             
-            // loop..
-            requestAnimationFrame(() => this.render());
+            // loop when scrolling..
+            if ( scrollingSpeed !== 0 ) {
+                requestAnimationFrame(() => this.render());
+            } else {
+                window.addEventListener( 'scroll', () => requestAnimationFrame(() => this.render()), { once: true, passive: true })
+            }
         }
     }
 


### PR DESCRIPTION
using a console.log statement in the SmoothScroll render() function that outputs the timestamp (hh:mm:ss) and the current value of scrollingSpeed to illustrate the difference in how often the function runs:

before (runs 60x per second, even before the user has started scrolling): 
<img width="1200" alt="before" src="https://user-images.githubusercontent.com/4021481/73398639-d8acbd80-42b3-11ea-89a7-bc30441e4b9e.png">

after (runs only while the user is scrolling; stops when they stop scrolling and starts again when they scroll again):
<img width="1200" alt="after" src="https://user-images.githubusercontent.com/4021481/73398638-d8acbd80-42b3-11ea-8613-58b10edae735.png">
